### PR TITLE
Agregada opción para indicar el inline_level del dumper de Yaml

### DIFF
--- a/Form/DataTransformer/ArrayToYamlTransformer.php
+++ b/Form/DataTransformer/ArrayToYamlTransformer.php
@@ -19,6 +19,16 @@ use Symfony\Component\Yaml\Yaml;
  */
 class ArrayToYamlTransformer implements DataTransformerInterface
 {
+    private $inlineLevel;
+
+    /**
+     * ArrayToYamlTransformer constructor.
+     * @param $inlineLevel
+     */
+    public function __construct($inlineLevel)
+    {
+        $this->inlineLevel = $inlineLevel;
+    }
 
     public function transform($value)
     {
@@ -26,7 +36,7 @@ class ArrayToYamlTransformer implements DataTransformerInterface
             return;
         }
 
-        return Yaml::dump($value);
+        return Yaml::dump($value, $this->inlineLevel);
     }
 
     public function reverseTransform($value)

--- a/Form/Type/YamlType.php
+++ b/Form/Type/YamlType.php
@@ -5,6 +5,7 @@ namespace gbenitez\Bundle\AttributeBundle\Form\Type;
 use gbenitez\Bundle\AttributeBundle\Form\DataTransformer\ArrayToYamlTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Manuel Aguirre <programador.manuel@gmail.com>
@@ -24,7 +25,15 @@ class YamlType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addModelTransformer(new ArrayToYamlTransformer());
+        $builder->addModelTransformer(new ArrayToYamlTransformer($options['inline_level']));
     }
 
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'inline_level' => 1000,
+        ]);
+
+        $resolver->setAllowedTypes('inline_level', 'numeric');
+    }
 }


### PR DESCRIPTION
Con esta opción que por defecto es 1000, es posible indicar a partir de que
nivel de profundidad del arreglo, los items internos se mostraran en linea
y no uno debajo del otro.
